### PR TITLE
feat(career): resume refresh + career Pages site + LinkedIn drafts + weekly cadence

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Career Pages
+
+# Publishes the portfolio + PII-scrubbed resume as a static site.
+# Rebuilt from cv/ on every push to main — no committed HTML build output.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cv/**'
+      - 'scripts/build_pages.py'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Build static site (stdlib only)
+        run: python scripts/build_pages.py
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 resume.pdf
 resume.html
 
+# Built static Pages output (regenerated in CI from cv/)
+public/
+
 
 # Agent OS
 .agent-os/cache/

--- a/cv/va_resume.md
+++ b/cv/va_resume.md
@@ -45,6 +45,7 @@ Combines hands-on technical authority in OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus
 - **Subsea and riser authority:** Delivered 100+ offshore riser and subsea projects across Gulf of Mexico, West Africa, Asia-Pacific, Guyana, and Venezuela for major operators including BP, Shell, Chevron, ExxonMobil, ENI, Murphy, Reliance, Talos, and others.
 - **Emergency response leadership:** Engineering Manager for BP Macondo containment riser response; delivered a complete containment riser design in 8 weeks versus a typical multi-year cycle by repurposing existing assets.
 - **Digital transformation:** Built Python/API-driven automation and digital twin workflows for OrcaFlex, AQWA, OrcaWave, ANSYS, COMSOL, BSEE field economics, drilling analytics, production surveillance, and fitness-for-service assessment.
+- **Open, demonstrable engineering & AI:** Publish deterministic, unit-tested engineering analyses as live public tools — a Gulf of Mexico field-economics & well-analytics site on public BSEE data ([worldenergydata, live](https://vamseeachanta.github.io/worldenergydata/)), an open offshore engineering library (digitalmodel: OrcaWave/AQWA benchmarks, 221 S-N fatigue curves across 17 standards, subsea/riser analysis), and a Raw-to-Knowledge playbook for AI-ready engineering data; AI/LLM-augmented workflows that compress analysis cycles while preserving standards traceability.
 - **Standards and technical credibility:** API committee participant/contributor for API-RP-16Q, API-RP-17G, and API-RP-17G2; author/co-author of technical publications for OTC, OMAE, IADC, and World Oil.
 
 ## Core Competencies
@@ -53,7 +54,7 @@ Combines hands-on technical authority in OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus
 
 **Analysis & Simulation:** Coupled dynamic analysis, diffraction/radiation analysis, mooring analysis, time-domain simulations, global riser analysis, pipelay and installation windows, detailed FEA, nonlinear elastic-plastic analysis, fracture mechanics, fatigue, corrosion simulation, hydrodynamics, operability assessment.
 
-**Software & Automation:** OrcaFlex / OrcFxAPI, AQWA, OrcaWave, ANSYS, Abaqus, COMSOL, Flexcom, Python, SQL, Git, Azure DevOps, pandas, NumPy, Matplotlib, Plotly/D3JS, API-driven model generation, batch execution, automated post-processing, engineering dashboards.
+**Software & Automation:** OrcaFlex / OrcFxAPI, AQWA, OrcaWave, ANSYS, Abaqus, COMSOL, Flexcom, Python, SQL, Git, Azure DevOps, pandas, NumPy, Matplotlib, Plotly/D3JS, API-driven model generation, batch execution, automated post-processing, engineering dashboards; AI/LLM-augmented engineering workflows and agentic automation, deterministic zero-server static web delivery (GitHub Pages).
 
 **Standards & Governance:** API-RP-16Q, API-RP-17G, API-RP-17G2, API 579-1 / ASME FFS-1, BS 7910, DNV offshore recommended practices, ASME VIII, engineering assurance, contractor deliverable review, design basis development, technical risk assessment.
 
@@ -94,6 +95,7 @@ Combines hands-on technical authority in OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus
 - **Trendsetter intervention system:** Supported intervention system design for water depths from 1,500 ft to 10,000 ft and pressures of 15,000–17,500 psi, including global riser analysis, connector/flange specifications, vessel stroke checks, and upper/lower riser configurations.
 - **Fitness-for-service automation:** Built Python workflows using pandas, NumPy, Matplotlib, and D3JS for wall-thickness processing, defect identification, API 579-1/ASME FFS-1 assessments, and BS 7910 fracture mechanics.
 - **Mooring corrosion simulation:** Modeled damaged subsea mooring line corrosion in COMSOL using fluid mechanics, mass transfer, diffusion, and electrochemical models; automated model processing with COMSOL Java API, MATLAB, and batch workflows.
+- **Open engineering & AI tooling:** Built and shipped public, deterministic engineering sites and libraries — [worldenergydata](https://vamseeachanta.github.io/worldenergydata/) (live GoM field economics & well analytics on BSEE data: Lower-Tertiary NPVs, 56-well benchmarking, 3D well paths), digitalmodel (open offshore engineering library), and a Raw-to-Knowledge playbook — every result unit-tested and provenance-traced, delivered as zero-server static HTML, with AI/LLM as narrative support over deterministic cores.
 
 ### Engineering SME for Data Science Team, Occidental Petroleum
 **Sep 2017 – Dec 2020 | Houston, TX & Remote**
@@ -125,6 +127,7 @@ Combines hands-on technical authority in OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus
 - **42-inch Venezuela pipeline:** Thin-walled pipeline bending capacity and pipelay analysis beyond standard DNV D/t regime.
 - **SEWOL salvage:** Rapid-response hull FEA and automated ANSYS reporting for salvage operations.
 - **Drilling/riser digital twins:** Automated OrcaFlex model generation, batch execution, results extraction, and API 579 / BS 7910 integrity workflows.
+- **worldenergydata (open):** Live, deterministic Gulf of Mexico field-economics & well-analytics site on public BSEE data — Lower-Tertiary NPVs, 56-well benchmarking, interactive 3D well paths; unit-tested numbers with full provenance.
 
 ## Education & Credentials
 

--- a/docs/linkedin/announcement-post.md
+++ b/docs/linkedin/announcement-post.md
@@ -1,0 +1,41 @@
+# LinkedIn Announcement Post — draft (for #18)
+
+> Publishing is owner-executed. Do NOT auto-post. Attach the images listed below.
+
+## Post copy
+
+```
+Engineers don't trust black boxes. So I built the opposite.
+
+Over the last few months I've been turning decades of offshore engineering into open, deterministic, demonstrable tools — and putting them on the public web where anyone can check the math.
+
+The first is live: a Gulf of Mexico field-economics & well-analytics site built entirely on public BSEE data — Lower-Tertiary field NPVs, well benchmarking across 56 wells, and interactive 3D well paths.
+🔗 https://vamseeachanta.github.io/worldenergydata/
+
+Why engineers seem to like it:
+• Every number is computed by unit-tested code and frozen — the page can't fudge a result.
+• No API key, no login, no server. Pure static HTML. Free and permanent.
+• Where the data is incomplete, the page says so — no fabricated gaps.
+
+Same principle behind my open engineering library (digitalmodel: OrcaWave/AQWA benchmarks, 221 S-N fatigue curves, subsea & riser analysis) and the Raw-to-Knowledge Playbook for making engineering data AI-ready.
+
+23 years of subsea engineering taught me the answer matters less than whether you can trust how you got it. AI doesn't change that — it raises the bar.
+
+Curious what production & subsea engineers think: what analysis would you want made open and verifiable next?
+
+#OffshoreEngineering #SubseaEngineering #PetroleumEngineering #ArtificialLift #AI #EnergyTech #DigitalTwin
+```
+
+## Images (4-6, in order)
+
+1. worldenergydata landing page (the cards + portfolio NPV table)
+2. Julia field economics — NPV table / timeline
+3. 3D well-path capture (Plotly view)
+4. digitalmodel — an RAO benchmark or OCIMF coefficient-explorer chart
+5. (optional) the well-benchmarking table (56 wells)
+
+## Notes
+
+- Tone deliberately mirrors the credible-to-engineers style (deterministic, honest about limits) — the same framing that made the reference post land.
+- First comment idea (drives reach): drop the digitalmodel + Raw-to-Knowledge repo links in the first comment rather than the post body, to keep the post link-count low for the algorithm.
+- Best post time: Tue–Thu, ~8-9am CT.

--- a/docs/linkedin/profile.md
+++ b/docs/linkedin/profile.md
@@ -1,0 +1,65 @@
+# LinkedIn Profile — Vamsee Achanta (draft for #14 / #17)
+
+> Drafted for review. LinkedIn edits are applied by Vamsee (external). Items marked **[CONFIRM]** need a decision before publishing.
+
+## Headline (finalized: Option A)
+
+```
+Offshore & Subsea Engineering Leader | Founder, AceEngineer | Building AI-Augmented Engineering Workflows
+```
+
+## About
+
+```
+I've spent 23+ years taking offshore oil & gas projects from concept to installed steel on the seabed — risers, pipelines, moorings, umbilicals, FPSOs — in water depths to 6,000 ft, across the Gulf of Mexico, Brazil, West Africa, the Middle East, and Australasia.
+
+What sets the last decade apart: I build the software that does the engineering. 50+ physics-based algorithms running in production, real-time drilling and production analytics serving thousands of wells, digital twins, and AI-augmented workflows that compress weeks of analysis into hours — without giving up rigor or traceability to the standards (DNV, API, BS).
+
+A few things I'm proud of:
+• Led 20+ engineers and designers on the BP Macondo Containment Riser response and WoodFibre FLNG.
+• Chevron Jack St. Malo SCR design, BP Thunderhorse semisubmersible analysis, Guyana Yellowtail umbilical installation, and the Sewol Ferry salvage offshore Korea.
+• Author/contributor on API-RP-16Q, 17G/17G2, ASCE COPRI MRE, and the IADC Floating Drilling Equipment & Operations manual.
+
+Lately I've been making the engineering itself open and demonstrable. Live examples:
+→ worldenergydata — deterministic Gulf of Mexico field economics & well analytics on public data: https://vamseeachanta.github.io/worldenergydata/
+→ digitalmodel — open offshore engineering library (OrcaWave/AQWA hydrodynamic benchmarks, 221 S-N fatigue curves across 17 standards, subsea/riser/cathodic-protection analysis)
+→ Raw-to-Knowledge Playbook — turning raw engineering data into trustworthy, AI-ready knowledge
+
+Every number on those sites is computed by unit-tested code and shown with its provenance — no black boxes, no API keys, no fabricated gaps.
+
+P.E. | MS Mechanical Engineering, Texas A&M | B.Tech, IIT Madras | CFA Level I
+
+If you're working on deepwater engineering, engineering automation, or AI for energy — let's talk.
+Houston, TX · vamsee.achanta@aceengineer.com
+```
+
+## Featured (pin these — pictures matter here)
+
+- **worldenergydata live site** — https://vamseeachanta.github.io/worldenergydata/ · thumbnail: landing-page screenshot
+- **digitalmodel** — GitHub repo link · thumbnail: an RAO benchmark or OCIMF coefficient-explorer chart
+- **Raw-to-Knowledge Playbook** — repo link · thumbnail: a lane flowchart
+- **The announcement post** (see `announcement-post.md`) — once published, pin it
+- Optional: an OTC/SPE publication or World Oil article link
+
+## Experience (highlights — fill dates/employers from full resume)
+
+- **Founder / Principal Engineer — AceEngineer** (Houston, TX). Offshore & subsea engineering consultancy; AI-augmented engineering tooling (digitalmodel, worldenergydata, deckhand). Add concrete outcomes + a link/figure per entry.
+- **[CONFIRM] VP of Engineering — FDAS (Frontier Deepwater)**. Your bio lists this as the current role, but FDAS is private/confidential client context — decide whether to name the employer publicly, name it generically ("a deepwater operator/EPC"), or omit. Do not auto-publish.
+- Prior roles: pull employer names + dates from `cv/va_resume.md` (not in the bio). Each: 2-3 outcome bullets with a standard/figure.
+
+## Skills (top to surface)
+
+Subsea Engineering · Riser Analysis (SCR/SLWR) · Mooring Systems · Pipeline Engineering · OrcaFlex · ANSYS AQWA · Spectral/Rainflow Fatigue (DNV-RP-C203) · Fitness-for-Service (API 579 / BS 7910) · Python · Machine Learning · Data Engineering · Digital Twins · Engineering Automation · AI / LLM Applications
+
+## Media checklist
+
+- [ ] Professional profile photo
+- [ ] Banner image (on-brand: subsea/offshore + a subtle data/AI motif)
+- [ ] Screenshots: worldenergydata landing, Julia NPV table, 3D well-path capture
+- [ ] One chart from digitalmodel (RAO benchmark or OCIMF explorer)
+
+## Open decisions
+
+- [ ] **[CONFIRM]** Current-employer line (FDAS public / generic / omit)
+- [ ] Public contact level (email/phone on profile?)
+- [ ] Confirm prior-role employers & dates from full resume

--- a/docs/linkedin/profile.md
+++ b/docs/linkedin/profile.md
@@ -30,8 +30,10 @@ Every number on those sites is computed by unit-tested code and shown with its p
 P.E. | MS Mechanical Engineering, Texas A&M | B.Tech, IIT Madras | CFA Level I
 
 If you're working on deepwater engineering, engineering automation, or AI for energy — let's talk.
-Houston, TX · vamsee.achanta@aceengineer.com
+Houston, TX
 ```
+
+> Contact default applied: **LinkedIn-only** (no public email/phone in the About). To override, append `· vamsee.achanta@aceengineer.com` when you apply it.
 
 ## Featured (pin these — pictures matter here)
 
@@ -44,7 +46,7 @@ Houston, TX · vamsee.achanta@aceengineer.com
 ## Experience (highlights — fill dates/employers from full resume)
 
 - **Founder / Principal Engineer — AceEngineer** (Houston, TX). Offshore & subsea engineering consultancy; AI-augmented engineering tooling (digitalmodel, worldenergydata, deckhand). Add concrete outcomes + a link/figure per entry.
-- **[CONFIRM] VP of Engineering — FDAS (Frontier Deepwater)**. Your bio lists this as the current role, but FDAS is private/confidential client context — decide whether to name the employer publicly, name it generically ("a deepwater operator/EPC"), or omit. Do not auto-publish.
+- **VP of Engineering — deepwater field-development company** (default applied: **generic**, to avoid naming a confidential client). Override to the real entity name only if you're comfortable making the employment public. Do not auto-publish.
 - Prior roles: pull employer names + dates from `cv/va_resume.md` (not in the bio). Each: 2-3 outcome bullets with a standard/figure.
 
 ## Skills (top to surface)
@@ -58,8 +60,8 @@ Subsea Engineering · Riser Analysis (SCR/SLWR) · Mooring Systems · Pipeline E
 - [ ] Screenshots: worldenergydata landing, Julia NPV table, 3D well-path capture
 - [ ] One chart from digitalmodel (RAO benchmark or OCIMF explorer)
 
-## Open decisions
+## Decisions (defaults applied — override at apply-time)
 
-- [ ] **[CONFIRM]** Current-employer line (FDAS public / generic / omit)
-- [ ] Public contact level (email/phone on profile?)
-- [ ] Confirm prior-role employers & dates from full resume
+- [x] Current-employer line → **generic** ("VP of Engineering, a deepwater field-development company"). Override with real name if desired.
+- [x] Public contact → **LinkedIn-only** (no public email/phone). Override by adding email.
+- [ ] Confirm prior-role employers & dates from full `cv/va_resume.md`

--- a/docs/weekly/2026-06-20-career-update.md
+++ b/docs/weekly/2026-06-20-career-update.md
@@ -1,0 +1,38 @@
+# Weekly Career Update — 2026-06-20
+
+> First instance / template. The "shipped this week" list below is from session context; **regenerate from the `gh search` query in `cadence.md`** once available, to catch anything missed.
+
+## Shipped this week (public-safe)
+
+- **worldenergydata GitHub Pages site went LIVE** — https://vamseeachanta.github.io/worldenergydata/ (PR worldenergydata#514). Deterministic Gulf of Mexico field economics, 56-well benchmarking, interactive 3D well paths — all on public BSEE data, every number unit-tested and shown with provenance.
+- **Lower-Tertiary portfolio expansion** — 7-field economics + benchmarking + portfolio views (branch `feat/pages-lt-portfolio`, PR pending).
+- **Ecosystem Pages initiative launched** — a pattern to make each repo's work openly demonstrable (epic workspace-hub#3223).
+
+_(Excluded from public surfaces: private client work — FDAS/ACMA/strategy/personal repos.)_
+
+## Proposed surface updates
+
+| Surface | Change |
+|---|---|
+| **Career Pages (#16)** | Add the live worldenergydata site as the lead portfolio link + a screenshot. |
+| **Resume (#15)** | New bullet: "Built and shipped a public, deterministic GoM field-economics & well-analytics site (worldenergydata) on BSEE data — unit-tested, provenance-traced, zero-server static delivery." |
+| **LinkedIn** | Publish the announcement post (`../linkedin/announcement-post.md`). This week's headline IS the launch. |
+
+## Ready-to-post LinkedIn draft (weekly short form)
+
+```
+New this week: a Gulf of Mexico field-economics & well-analytics site, live and fully open.
+Built on public BSEE data — Lower-Tertiary NPVs, 56-well benchmarking, interactive 3D well paths.
+Every number is computed by unit-tested code and shown with its provenance. No API key, no server.
+🔗 https://vamseeachanta.github.io/worldenergydata/
+What would you want made open and verifiable next?
+#OffshoreEngineering #SubseaEngineering #EnergyTech #AI
+```
+
+_(For the full launch post with images, use `../linkedin/announcement-post.md`. Publishing is owner-executed.)_
+
+## Carry-forward
+
+- [ ] Push/merge `feat/pages-lt-portfolio` → refresh the live site.
+- [ ] Finalize prior-role employers/dates in the LinkedIn profile.
+- [ ] Decide career-Pages PII handling (#16).

--- a/docs/weekly/cadence.md
+++ b/docs/weekly/cadence.md
@@ -1,0 +1,38 @@
+# Weekly Career-Update Cadence (for #19)
+
+Keep the three career surfaces — resume (teamresumes), career Pages site, and LinkedIn — current by feeding newly-shipped work into them every week. This is the personal-brand arm of the content→outreach flywheel.
+
+## When
+
+**Friday** (pick/confirm). ~20 minutes, or run the drafting agent and review.
+
+## Source signal — what shipped this week
+
+```bash
+# Merged PRs across the ecosystem in the last 7 days
+gh search prs --owner vamseeachanta --merged "merged:>=$(date -d '7 days ago' +%F)" \
+  --limit 50 --json repository,number,title
+
+# Closed issues, same window (optional)
+gh search issues --owner vamseeachanta --state closed "closed:>=$(date -d '7 days ago' +%F)" \
+  --limit 50 --json repository,number,title
+```
+
+Filter to **public-safe wins** only (exclude private-repo client work: FDAS/ACMA/strategy/personal — see the ecosystem epic vamseeachanta/workspace-hub#3223 data-safety notes).
+
+## Weekly checklist
+
+1. **New live demo / result?** → add/refresh a link on the career Pages site (#16).
+2. **Notable shipped work?** → one resume bullet (teamresumes #15), with a link/figure.
+3. **One LinkedIn update** → either a profile tweak (Featured/Experience) or a short post draft.
+4. Record the week in `docs/weekly/<YYYY-MM-DD>-career-update.md` (proposed changes + a ready-to-post LinkedIn draft). **Publishing stays owner-gated.**
+
+## Automation (optional)
+
+A scheduled cloud agent (`/schedule`) that runs the source-signal queries Friday morning, drafts `docs/weekly/<date>-career-update.md`, and opens it for review. It never posts — it only drafts. Hook to the same public-safe filter.
+
+## Guardrails
+
+- Public-safe only: never surface private-repo client content in a public post or the career site.
+- Resumes carry PII — render scrubbed for the public site (see #16).
+- Publishing to LinkedIn is owner-executed.

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -1,0 +1,219 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Build a static career/portfolio GitHub Pages site for teamresumes.
+
+Reuses the deterministic static-site pattern from worldenergydata: a stdlib-only
+generator renders source Markdown to static HTML with no server and no API key.
+
+PRIVACY: the public site renders a PII-SCRUBBED resume (email/phone/precise
+location removed; LinkedIn/GitHub kept). The source `cv/*.md` is unchanged — only
+the rendered HTML is scrubbed. Built `public/` is gitignored and regenerated in CI.
+
+Run:  python3 scripts/build_pages.py   (writes public/)
+"""
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CV = ROOT / "cv"
+PUBLIC = ROOT / "public"
+ASSETS = PUBLIC / "assets"
+
+# The one resume rendered publicly (owner-consented). Others stay private until consent.
+PUBLIC_RESUME = "va_resume.md"
+
+HEADLINE = "Offshore & Subsea Engineering Leader | Founder, AceEngineer | Building AI-Augmented Engineering Workflows"
+
+DEMOS = [
+    ("worldenergydata — live", "https://vamseeachanta.github.io/worldenergydata/",
+     "Deterministic Gulf of Mexico field economics & well analytics on public BSEE data: Lower-Tertiary NPVs, 56-well benchmarking, interactive 3D well paths."),
+    ("digitalmodel", "https://github.com/vamseeachanta/digitalmodel",
+     "Open offshore engineering library — OrcaWave/AQWA hydrodynamic benchmarks, 221 S-N fatigue curves across 17 standards, subsea/riser/cathodic-protection analysis."),
+    ("Raw-to-Knowledge Playbook", "https://github.com/vamseeachanta/raw-to-knowledge-playbook",
+     "Field-tested methodology for turning raw engineering data into trustworthy, AI-ready knowledge."),
+]
+
+# ---------------------------------------------------------------------------
+# PII scrub — applied to the rendered resume only.
+# ---------------------------------------------------------------------------
+_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_PHONE = re.compile(r"(?<!\d)(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)")
+
+
+def scrub(md: str) -> str:
+    """Remove email/phone and the explicit Email:/Phone: contact labels.
+    Keep LinkedIn/GitHub links and city-level location."""
+    # Drop a leading "**Email:** ... | **Phone:** ..." line entirely.
+    lines = []
+    for line in md.splitlines():
+        if re.search(r"\*\*Email:\*\*|\*\*Phone:\*\*", line):
+            continue
+        line = _EMAIL.sub("[contact via LinkedIn]", line)
+        line = _PHONE.sub("", line)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def strip_frontmatter(md: str) -> str:
+    if md.startswith("---"):
+        end = md.find("\n---", 3)
+        if end != -1:
+            nl = md.find("\n", end + 1)
+            return md[nl + 1:] if nl != -1 else ""
+    return md
+
+
+# ---------------------------------------------------------------------------
+# Minimal Markdown -> HTML (ATX headings, lists, tables, hr, bold, links,
+# inline code). Raw HTML like <br> passes through untouched.
+# ---------------------------------------------------------------------------
+_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BOLD = re.compile(r"\*\*([^*]+)\*\*")
+_CODE = re.compile(r"`([^`]+)`")
+
+
+def _inline(text: str) -> str:
+    text = _CODE.sub(lambda m: f"<code>{html.escape(m.group(1))}</code>", text)
+    text = _BOLD.sub(r"<strong>\1</strong>", text)
+    text = _LINK.sub(r'<a href="\2">\1</a>', text)
+    return text
+
+
+def md_to_html(md: str) -> str:
+    lines = md.splitlines()
+    out: list[str] = []
+    i, n = 0, len(lines)
+    para: list[str] = []
+
+    def flush():
+        if para:
+            out.append(f"<p>{_inline(' '.join(para))}</p>")
+            para.clear()
+
+    while i < n:
+        s = lines[i].strip()
+        if s.startswith("|") and i + 1 < n and re.match(r"^\s*\|[\s:\-|]+\|\s*$", lines[i + 1]):
+            flush()
+            block = [lines[i], lines[i + 1]]
+            i += 2
+            while i < n and lines[i].strip().startswith("|"):
+                block.append(lines[i]); i += 1
+            cells = [[c.strip() for c in r.strip().strip("|").split("|")] for r in block]
+            head, _al, *body = cells
+            t = ["<div class='table-wrap'><table><thead><tr>"]
+            t += [f"<th>{_inline(c)}</th>" for c in head] + ["</tr></thead><tbody>"]
+            for row in body:
+                t.append("<tr>" + "".join(f"<td>{_inline(c)}</td>" for c in row) + "</tr>")
+            out.append("".join(t) + "</tbody></table></div>")
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)$", s)
+        if m:
+            flush(); lvl = len(m.group(1))
+            out.append(f"<h{lvl}>{_inline(m.group(2))}</h{lvl}>"); i += 1; continue
+        if s in ("---", "***", "___"):
+            flush(); out.append("<hr>"); i += 1; continue
+        if re.match(r"^[-*]\s+", s):
+            flush(); items = []
+            while i < n and re.match(r"^[-*]\s+", lines[i].strip()):
+                items.append(re.sub(r"^[-*]\s+", "", lines[i].strip())); i += 1
+            out.append("<ul>" + "".join(f"<li>{_inline(it)}</li>" for it in items) + "</ul>")
+            continue
+        if not s:
+            flush(); i += 1; continue
+        para.append(s); i += 1
+    flush()
+    return "\n".join(out)
+
+
+STYLE = """:root{--fg:#1a2230;--muted:#5b6675;--bg:#f7f8fa;--card:#fff;--line:#e2e6ec;--brand:#0f4c81}
+*{box-sizing:border-box}
+body{margin:0;font:16px/1.6 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg)}
+header.site,footer.site{padding:14px 22px;background:var(--card);border-bottom:1px solid var(--line)}
+footer.site{border-top:1px solid var(--line);border-bottom:0;color:var(--muted);font-size:14px;margin-top:48px}
+.home{color:var(--brand);text-decoration:none;font-weight:700}
+main{max-width:900px;margin:0 auto;padding:28px 22px}
+.hero{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:28px;display:flex;gap:24px;align-items:center;flex-wrap:wrap}
+.photo{width:120px;height:120px;border-radius:50%;background:#dde3ea;display:flex;align-items:center;justify-content:center;color:var(--muted);font-size:13px;text-align:center;flex:0 0 auto}
+.hero h1{margin:.1em 0;font-size:26px}
+.headline{color:var(--brand);font-weight:600;margin:.2em 0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:16px;margin:26px 0}
+.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px;text-decoration:none;color:inherit;transition:.15s;display:block}
+.card:hover{border-color:var(--brand);box-shadow:0 4px 16px rgba(15,76,129,.12);transform:translateY(-2px)}
+.card h3{margin:.1em 0 .4em;color:var(--brand)}
+.card p{color:var(--muted);font-size:14px;margin:0}
+.content h2{margin-top:1.6em;border-bottom:1px solid var(--line);padding-bottom:.2em}
+.content h3{margin-top:1.3em}
+.table-wrap{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:14px}
+th,td{border:1px solid var(--line);padding:6px 10px;text-align:left}
+a{color:var(--brand)}
+hr{border:0;border-top:1px solid var(--line);margin:1.4em 0}
+.note{background:#fff8ec;border:1px solid #f1ddb3;border-radius:8px;padding:10px 14px;font-size:13px;color:#8a5a00;margin:14px 0}
+"""
+
+
+def shell(title: str, body: str, *, home=True) -> str:
+    nav = '<a class="home" href="index.html">&larr; Vamsee Achanta</a>' if home else '<span class="home">Vamsee Achanta, P.E.</span>'
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{html.escape(title)}</title><link rel="stylesheet" href="assets/style.css"></head>
+<body><header class="site">{nav}</header><main>{body}</main>
+<footer class="site"><p>Built as a deterministic static site (no server, no tracking). Source: github.com/vamseeachanta/teamresumes.</p></footer>
+</body></html>"""
+
+
+def build():
+    PUBLIC.mkdir(exist_ok=True)
+    ASSETS.mkdir(exist_ok=True)
+    (ASSETS / "style.css").write_text(STYLE, encoding="utf-8")
+
+    # Resume page (scrubbed)
+    resume_md = CV / PUBLIC_RESUME
+    has_resume = resume_md.exists()
+    if has_resume:
+        body = md_to_html(strip_frontmatter(scrub(resume_md.read_text(encoding="utf-8"))))
+        (PUBLIC / "resume.html").write_text(shell(
+            "Vamsee Achanta — Resume",
+            '<div class="note">Public resume: direct contact details removed by design. '
+            'Reach out via <a href="https://www.linkedin.com/in/vamseeachanta">LinkedIn</a>.</div>'
+            f'<div class="content">{body}</div>',
+        ), encoding="utf-8")
+
+    # Landing / portfolio
+    cards = "".join(
+        f'<a class="card" href="{url}"><h3>{html.escape(name)} &rarr;</h3><p>{html.escape(desc)}</p></a>'
+        for name, url, desc in DEMOS
+    )
+    resume_link = '<p><a href="resume.html">Full resume &rarr;</a></p>' if has_resume else ""
+    landing = shell("Vamsee Achanta, P.E. — Offshore & Subsea Engineering + AI", f"""
+<section class="hero">
+  <div class="photo">photo<br>placeholder</div>
+  <div>
+    <h1>Vamsee Achanta, P.E.</h1>
+    <p class="headline">{html.escape(HEADLINE)}</p>
+    <p>23+ years across the offshore lifecycle — risers, pipelines, moorings, FPSOs, to 6,000 ft —
+    now building deterministic, AI-augmented engineering tools and putting the work in the open.</p>
+    {resume_link}
+  </div>
+</section>
+<h2>Live work</h2>
+<div class="cards">{cards}</div>
+<h2>How this site works</h2>
+<p>Static HTML, no server, no tracking. The resume renders from Markdown with contact
+details scrubbed; the live-work links go to deterministic, unit-tested tools where every
+number is shown with its provenance.</p>
+""", home=False)
+    (PUBLIC / "index.html").write_text(landing, encoding="utf-8")
+
+    pages = sorted(p.name for p in PUBLIC.glob("*.html"))
+    print(f"Built {len(pages)} pages: {', '.join(pages)} (resume {'included' if has_resume else 'MISSING'})")
+
+
+if __name__ == "__main__":
+    build()


### PR DESCRIPTION
Implements the career-presence overhaul epic #14.

## What's here
- **#15 Resume refresh** (`cv/va_resume.md`): surfaces recent open/AI work — worldenergydata (live), digitalmodel, Raw-to-Knowledge — plus AI/LLM in competencies. Surgical additions, no rewrite.
- **#16 Career Pages site**: stdlib `scripts/build_pages.py` renders a portfolio landing (headline + live-demo cards) and a **PII-scrubbed** resume (strips email/phone, keeps LinkedIn/GitHub — verified 0 PII in output), plus `.github/workflows/pages.yml`. Built `public/` is gitignored, regenerated in CI.
- **#17 LinkedIn profile** (`docs/linkedin/profile.md`): headline (Option A), About, Featured, Experience, Skills; privacy-safe defaults applied (generic current-employer line, LinkedIn-only contact), overridable at apply-time.
- **#18 Announcement post** (`docs/linkedin/announcement-post.md`): launch post + image set.
- **#19 Weekly cadence** (`docs/weekly/`): Friday routine + first weekly update.

## Guards
- Public resume render is PII-scrubbed; source `cv/*.md` unchanged.
- LinkedIn profile/post are drafts — **publishing is owner-executed** (no auto-post).
- One-time after merge: Settings → Pages → Source = GitHub Actions.

Refs #14 #15 #16 #17 #18 #19. Part of ecosystem Pages epic vamseeachanta/workspace-hub#3223.
