### PR TITLE
content(career): API-builder / firm-first reframe — resume + LinkedIn + career

### DIFF
--- a/cv/career-page-api-centric.md
+++ b/cv/career-page-api-centric.md
@@ -1,0 +1,60 @@
+# Career Page - API-centric / firm-first portfolio copy
+
+> **DRAFT - Vamsee publishes manually.** Short portfolio copy for the public career/portfolio
+> page, tying the work to live API paths + report URLs. Firm-first per aceengineer-strategy#94.
+> Honesty rule: offshore is live proof; CAD/CAM, manufacturing, electrical, safety are
+> "onboarding" API paths, never shipped capability. Replace bracketed `[...]` with real links.
+
+---
+
+## Hero
+
+**AceEngineer builds Deckhand - the API for real-world engineering work.**
+
+Every engineering workflow is an API path. One call - `POST /api/run` - returns a **standards-traceable HTML report URL**. Same input, same output, every time. Built on the open-source `digitalmodel` library (7,000+ standard-mapped functions, 42 standards), so every result is deterministic and auditable.
+
+*Offshore is live today. More domains are onboarding.*
+
+[Try a live API call -> report URL] · [See the API catalog] · [aceengineer.com]
+
+---
+
+## How it works (the contract)
+
+```
+POST /api/run
+  { "ref": "digitalmodel:mooring-fatigue@2",
+    "domain": "floating-marine", "subdomain": "mooring", "inputs": {...} }
+-> { "status": "PASS",
+     "report_url": "https://vamseeachanta.github.io/deckhand-sandbox/.../report.html",
+     "artifacts": [...], "duration_s": 12.4 }
+```
+
+- **Every workflow is an API path** - cataloged, callable, versioned.
+- **Every call returns a deliverable URL** - a report with the governing standard (DNV, API) cited inline.
+- **Chat is one client.** Telegram, website buttons, and cron jobs all call the same `/api/run`.
+
+---
+
+## Live API paths (offshore - proven)
+
+| API path | What it returns | Standard |
+|---|---|---|
+| Mooring fatigue / global analysis | Standards-traceable screening report URL | DNV |
+| Subsea-pipeline screening | Deterministic report across hundreds of golden cases | DNV-RP-F105 |
+| Installation / umbilical-window analysis | Installation-window report (Yellowtail/Talos lineage) | DNV / API |
+| Field-economics screening | BSEE-data analytics over 200+ GoM fields | - |
+
+[View live report examples -> deckhand-sandbox gallery]
+
+## Onboarding (roadmap - not yet shipped)
+
+CAD/CAM · manufacturing · electrical · safety - being onboarded as new API paths. Listed as roadmap, not capability.
+
+---
+
+## The credibility beneath the platform
+
+23+ years of high-consequence offshore engineering - naval architecture, subsea, risers, moorings, installation - for BP, Shell, Chevron, ExxonMobil, ENI, Talos, and others. Engineering Manager for the BP Macondo containment riser response (complete design in 8 weeks). Texas P.E. API-RP-16Q / 17G / 17G2 committee contributor. That track record is why the API can be trusted on real, high-stakes work.
+
+[Full resume] · [LinkedIn] · [GitHub]

--- a/cv/linkedin/profile-api-centric.md
+++ b/cv/linkedin/profile-api-centric.md
@@ -25,7 +25,7 @@ I'm building **Deckhand - the API for real-world work.**
 
 The idea is simple: every engineering workflow should be an API path. You make one call - `POST /api/run` - and you get back a **standards-traceable HTML report URL**. Same input, same output, every time. No black box: it runs on the open-source `digitalmodel` library (7,000+ standard-mapped functions across 42 engineering standards), so every result is deterministic, inspectable, and reproducible.
 
-Why this matters: most "AI for engineering" stops at a chat answer you can't audit or hand to a client. Deckhand ends at a deliverable - a report URL with the governing standard (DNV, API) cited inline, backed by golden test cases. Chat is just one client of the API; so are website buttons and scheduled jobs.
+Why this matters: most engineering chatbots stop at a chat answer you can't audit or hand to a client. Deckhand ends at a deliverable - a report URL with the governing standard (DNV, API) cited inline, backed by golden test cases. Chat is just one client of the API; so are website buttons and scheduled jobs.
 
 Offshore engineering is the live proof. Mooring, subsea-pipeline, riser, and installation screening are firing today as DNV/API-traceable API paths that return published reports. More domains - CAD/CAM, manufacturing, electrical, safety - are onboarding as new API paths.
 

--- a/cv/linkedin/profile-api-centric.md
+++ b/cv/linkedin/profile-api-centric.md
@@ -1,0 +1,99 @@
+# LinkedIn Profile - API-centric / firm-first draft
+
+> **DRAFT - Vamsee posts manually.** Nothing here is published. Firm-first reframe per
+> aceengineer-strategy#94. Honesty rule: offshore is live proof; CAD/CAM, manufacturing,
+> electrical, and safety are "onboarding" API paths - never claimed as shipped capability.
+> Replace bracketed `[...]` URLs with the real live links before posting.
+
+---
+
+## Headline (<=220 chars)
+
+> Founder, AceEngineer / Deckhand - the API for real-world engineering work | One call returns a standards-traceable report URL | P.E., 23+ yrs offshore & subsea as the credibility beneath the platform
+
+(Length: 199 characters.)
+
+**Alternates:**
+- Building Deckhand - the API for real-world work | Every engineering workflow is an API path -> a standards-traceable report | P.E. | Offshore live, more domains onboarding
+- Founder, AceEngineer / Deckhand | The API for engineering work that shows its work | Deterministic, standards-traceable reports on open-source digitalmodel | P.E.
+
+---
+
+## About
+
+I'm building **Deckhand - the API for real-world work.**
+
+The idea is simple: every engineering workflow should be an API path. You make one call - `POST /api/run` - and you get back a **standards-traceable HTML report URL**. Same input, same output, every time. No black box: it runs on the open-source `digitalmodel` library (7,000+ standard-mapped functions across 42 engineering standards), so every result is deterministic, inspectable, and reproducible.
+
+Why this matters: most "AI for engineering" stops at a chat answer you can't audit or hand to a client. Deckhand ends at a deliverable - a report URL with the governing standard (DNV, API) cited inline, backed by golden test cases. Chat is just one client of the API; so are website buttons and scheduled jobs.
+
+Offshore engineering is the live proof. Mooring, subsea-pipeline, riser, and installation screening are firing today as DNV/API-traceable API paths that return published reports. More domains - CAD/CAM, manufacturing, electrical, safety - are onboarding as new API paths.
+
+Underneath the platform is 23+ years of high-consequence offshore engineering: naval architecture, subsea systems, risers, moorings, and installation for BP, Shell, Chevron, ExxonMobil, and others - including Engineering Manager for the BP Macondo containment riser response. A Texas P.E. license and that track record are the credibility that lets the API be trusted on real, high-stakes work.
+
+That's the whole thesis: AceEngineer builds the API for real-world engineering work, with two decades of offshore proof underneath it.
+
+See a live API call return a real report -> [live report URL: vamseeachanta.github.io/deckhand-sandbox/.../report.html]
+
+---
+
+## Featured (suggest 2-3 items)
+
+1. **API catalog** - the list of callable engineering workflows (API paths). [api-catalog page on aceengineer.com once published]
+2. **A live `report.html`** - one real `POST /api/run` output, standards-traceable. [vamseeachanta.github.io/deckhand-sandbox/.../report.html]
+3. **AceEngineer website** - the platform and the API contract (`deckhand-api` page). [aceengineer.com]
+
+---
+
+## Experience (top role bullets, reframed)
+
+### Founder & Principal Engineer - AceEngineer / Deckhand
+*Jun 2012 - Present*
+
+- Building Deckhand - the API for real-world engineering work: every workflow is an API path; one `POST /api/run` returns a standards-traceable HTML report URL.
+- Drove the open-source `digitalmodel` engine to 7,000+ standard-mapped functions across 42 standards - deterministic, inspectable results, not a black box.
+- Shipped live offshore proof: mooring, subsea-pipeline, riser, and installation screening as DNV/API-traceable API paths returning published report URLs.
+- Two decades of specialist offshore/subsea consulting (ExxonMobil Yellowtail, Talos, Chevron, Venezuela pipeline) is the credibility beneath the platform - and the source of its first API paths.
+
+### Naval Architect - Alan McClure & Associates
+*Dec 2023 - Present*
+
+- Marine global analysis for the WoodFibre LNG Terminal ($1.8B, BC): dual Floating Storage Terminals, coupled mooring, LNG-carrier berthing, via AQWA/OrcaWave/OrcaFlex.
+- Built Python/API digital twins for diffraction and mooring workflows - now running as Deckhand API paths.
+
+### VP of Engineering / Co-Founder - Frontier Deepwater Appraisal Solutions (FDAS)
+*Jun 2016 - Present*
+
+- Deepwater field-development concepts, riser/mooring systems, and a SQL/Python field-economics platform over 200+ GoM fields - now a Deckhand field-economics API path.
+- Led a 6,000 ft semisubmersible production-vessel concept and a 72-hour emergency hull FEA for the SEWOL salvage.
+
+### Engineering SME, Data Science Team - Occidental Petroleum
+*Sep 2017 - Dec 2020*
+
+- Deployed 50+ physics-based algorithms monitoring ~20,000 wells in real time; the production-analytics foundation Deckhand builds on.
+
+### Engineering Lead - 2H Offshore
+*Aug 2003 - Jun 2015*
+
+- Engineering Manager for the BP Macondo containment riser response - complete design in 8 weeks by repurposing existing assets.
+- 100+ riser/subsea assignments (Thunder Horse, Atlantis, Jack/St. Malo, KG-D6); API-RP-16Q committee contributor.
+
+---
+
+## Skills (ordered)
+
+1. Engineering platform / API design (workflow-as-API)
+2. Standards-traceable report automation
+3. Deterministic / golden-case testing
+4. Open-source `digitalmodel`
+5. Python automation (OrcFxAPI, pandas, NumPy)
+6. Naval architecture & floating systems
+7. Subsea & riser engineering
+8. Mooring & installation analysis
+9. OrcaFlex / AQWA / OrcaWave
+10. ANSYS / Abaqus / COMSOL FEA
+11. API 579 / BS 7910 fitness-for-service
+12. DNV / API offshore standards
+13. SQL & engineering data analytics
+14. Emergency-response engineering leadership
+15. Professional Engineer (P.E.), Texas

--- a/cv/va_resume_apibuilder.md
+++ b/cv/va_resume_apibuilder.md
@@ -1,0 +1,166 @@
+---
+margin-left: 1.4cm
+margin-right: 1.4cm
+margin-top: 1.2cm
+margin-bottom: 1.2cm
+title: Vamsee Achanta P.E. - Founder, AceEngineer / Deckhand - the API for real-world engineering work
+description-meta: Firm-first profile - founder/principal building Deckhand, the API for real-world engineering work, backed by 23+ years of naval architecture, subsea, and offshore engineering
+keywords:
+  - Deckhand
+  - AceEngineer
+  - engineering API
+  - standards-traceable reports
+  - digitalmodel
+  - workflow automation
+  - naval architecture
+  - subsea engineering
+  - mooring analysis
+  - OrcaFlex
+  - AQWA
+  - OrcaWave
+  - Python automation
+author:
+- Vamsee Achanta
+subject: 'cv_vamsee_achanta_api_builder'
+---
+
+<!-- DRAFT - firm-first / API-builder reframe of cv/va_resume.md.
+     Canonical va_resume.md is untouched. Every fact below is carried from the
+     canonical resume and reframed, not invented. Honesty rule: offshore is the
+     live proof; CAD/CAM, manufacturing, electrical, and safety are roadmap
+     ("onboarding") API paths, never claimed as shipped capability. -->
+
+# VAMSEE ACHANTA, P.E.
+## Founder, AceEngineer / Deckhand - the API for real-world engineering work
+
+**Email:** vamsee.achanta@aceengineer.com | **Phone:** 713-306-9029  
+**LinkedIn:** [linkedin.com/in/vamseeachanta](https://www.linkedin.com/in/vamseeachanta) | **GitHub:** [github.com/vamseeachanta](https://github.com/vamseeachanta) | **Location:** Houston, TX
+
+---
+
+## Summary
+
+Founder and principal engineer building **Deckhand - the API for real-world work**: every engineering workflow becomes an API path, and one call (`POST /api/run`) returns a **standards-traceable HTML report URL**. Same input, same output, every time. The platform runs on open-source **digitalmodel** - 7,000+ standard-mapped functions across 42 engineering standards - so the deliverable is deterministic and auditable, not a black box.
+
+Offshore engineering is the live proof: mooring, subsea-pipeline, riser, and installation workflows are firing today as DNV/API-traceable API paths that return published report URLs. Additional domains - CAD/CAM, manufacturing, electrical, and safety - are onboarding as new API paths.
+
+Beneath the platform sits 23+ years of high-consequence offshore engineering and a Texas P.E. license. The naval-architecture, subsea, and emergency-response track record is the credibility that lets the API be trusted on real, high-stakes work - it is the foundation under the product, not the headline.
+
+## The Platform: Deckhand
+
+- **Every workflow is an API path.** Engineering work is cataloged as callable routes (`domain / subdomain / workflow`); a single `POST /api/run` resolves the right standard-mapped function set and runs it.
+- **Every call returns a deliverable URL.** Each run mints a standards-traceable HTML report published to a public gallery - the work shows itself, with the governing standard cited inline.
+- **Deterministic by contract.** Backed by golden/canary cases (e.g. DNV-RP-F105 screening across hundreds of cases); the same input always returns the same output.
+- **Chat is one client.** Telegram/WhatsApp front-ends, website "try it" buttons, and scheduled jobs are all thin clients over the same `/api/run` path.
+- **Built on open source.** The compute layer is the open-source `digitalmodel` library (7,000+ standard-mapped functions, 42 standards), so results are inspectable and reproducible.
+- **Live today / onboarding next.** Offshore screening (mooring, subsea pipeline, riser, installation) is live and proven; CAD/CAM, manufacturing, electrical, and safety are API paths being onboarded.
+
+## What's Underneath: 23+ Years of Engineering Credibility
+
+- **Marine & floating systems:** Coupled marine global analysis, diffraction/radiation, mooring, and time-domain assessment for floating assets, LNG terminals, barges, tugs, and marine operations - including the WoodFibre LNG Terminal ($1.8B, British Columbia) dual-FST design.
+- **Subsea & riser authority:** 100+ offshore riser and subsea projects across the Gulf of Mexico, West Africa, Asia-Pacific, Guyana, and Venezuela for BP, Shell, Chevron, ExxonMobil, ENI, Murphy, Reliance, Talos, and others.
+- **Emergency response:** Engineering Manager for the BP Macondo containment riser response - complete design in 8 weeks versus a typical multi-year cycle by repurposing existing assets.
+- **Standards credibility:** API committee participant/contributor for API-RP-16Q, API-RP-17G, and API-RP-17G2; published with OTC, OMAE, IADC, and World Oil.
+- **Automation lineage:** A decade-plus of converting engineering workflows into Python/API tooling, digital twins, and production analytics - the direct precursor to building Deckhand.
+
+## Core Competencies
+
+**Platform & Software:** API design for engineering workflows, standards-traceable report generation, deterministic/golden-case testing, open-source `digitalmodel`, Python, OrcFxAPI, SQL, Git, Azure DevOps, pandas, NumPy, Matplotlib, Plotly/D3JS, batch execution, automated post-processing, engineering dashboards.
+
+**Marine & Subsea Engineering:** Naval architecture, floating systems, FST/FPSO/FPU concepts, LNG marine operations, risers (SCR, TTR, hybrid, lazy-wave, simple catenary), pipelines, umbilicals, jumpers, manifolds, moorings, CALM/SALM buoys, installation engineering, integrity management, decommissioning.
+
+**Analysis & Simulation:** Coupled dynamic analysis, diffraction/radiation analysis, mooring analysis, time-domain simulations, global riser analysis, pipelay and installation windows, detailed FEA, nonlinear elastic-plastic analysis, fracture mechanics, fatigue, corrosion simulation, hydrodynamics, operability assessment. Tools: OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus, COMSOL, Flexcom.
+
+**Standards & Governance:** API-RP-16Q, API-RP-17G, API-RP-17G2, API 579-1 / ASME FFS-1, BS 7910, DNV offshore recommended practices, ASME VIII, engineering assurance, design basis development, technical risk assessment.
+
+**Leadership:** Founder/principal, engineering team leadership, mentoring, client-facing technical advisory, project management, emergency response, cross-functional engineering/data-science integration.
+
+---
+
+## Professional Experience
+
+### Founder & Principal Engineer, AceEngineer / Deckhand
+**Jun 2012 - Present | Houston, TX & Remote**
+
+Building **Deckhand - the API for real-world engineering work** - the productization of two decades of offshore engineering into callable, standards-traceable API paths, on top of the open-source `digitalmodel` library.
+
+- **Deckhand API platform:** Defined the unifying contract where every engineering workflow is an API path and one `POST /api/run` returns a standards-traceable HTML report URL; chat, web, and cron are all clients of the same run path.
+- **Open-source engine:** Drove `digitalmodel` to 7,000+ standard-mapped functions across 42 engineering standards, so every result is deterministic, inspectable, and reproducible.
+- **Live offshore proof:** Shipped mooring, subsea-pipeline, riser, and installation screening as DNV/API-traceable API paths returning published report URLs, validated by golden/canary cases.
+- **Specialist offshore/subsea consulting (the credibility beneath the platform):** Delivered installation analysis, risers, pipelines, umbilicals, structural FEA, corrosion, and fitness-for-service for major operators and engineering contractors. Representative engagements:
+  - **ExxonMobil Yellowtail (Guyana):** Dynamic/static umbilical installation in ~6,000 ft water depth; evaluated 100+ load cases and installation windows to reduce execution risk.
+  - **42-inch thin-walled subsea pipeline (Venezuela):** Detailed FEA for bending-moment capacity at D/t = 67 outside standard DNV regime; OrcaFlex pipelay analysis automated via Python/API.
+  - **Talos Venice Limerock & Chevron Ballymore:** Static-umbilical, rigid-jumper, and manifold installation analysis with installation tables and dynamic limits.
+  - **Circular BOP design:** Nonlinear elastic-plastic ANSYS FEA of seals, connectors, and metal/elastomer behavior.
+  - **Riser & integrity digital twins:** Database-driven automation for drilling/top-tensioned/lazy-wave/simple-catenary risers, API 579 fitness-for-service, and BS 7910 fatigue/fracture workflows - the direct precursors to Deckhand API paths.
+
+### Naval Architect, Alan McClure & Associates
+**Dec 2023 - Present | Houston, TX**
+
+- **WoodFibre LNG Terminal - British Columbia ($1.8B project):** Detailed marine global analysis for two Floating Storage Terminals berthed side-by-side in ~35 m water depth - coupled FST/shore-mooring analysis for extreme weather, FST/LNGC/fender/mooring interaction checks, mooring support for LNG carriers up to 180,000 m3, via AQWA/OrcaWave/OrcaFlex.
+- **Diffraction and mooring failure investigations:** AQWA/OrcaWave diffraction and OrcaFlex global analysis for moored barges to evaluate mooring-line failure mechanisms in extreme weather.
+- **Tug floundering / passing-ship analysis:** Time-domain OrcaFlex assessment of tug motions and operational risk from passing-ship effects.
+- **Analysis automation:** Built Python/API digital twins for hull diffraction (AQWA/OrcaWave) and mooring (OrcaFlex/OrcFxAPI) workflows - automated model creation, execution, result extraction, and report generation. These workflows now run as Deckhand API paths.
+
+### VP of Engineering / Co-Founder, Frontier Deepwater Appraisal Solutions (FDAS)
+**Jun 2016 - Present | Houston, TX**
+
+- Lead venture-backed engineering and technology development for deepwater field-development concepts, riser/mooring systems, field economics, technical marketing, and operator engagement.
+- **6,000 ft semisubmersible production vessel concept:** Led feasibility and concept evaluation for converting idle 6th-generation drillships into production assets; delivered riser, mooring, and hurricane-condition analysis.
+- **GoM field-economics analytics platform:** Built a SQL/Python analytics platform on BSEE data for 200+ Gulf of Mexico fields, cutting field-evaluation time from weeks to days and screening stranded-asset opportunities - now a Deckhand field-economics API path.
+- **SEWOL salvage critical analysis:** Delivered emergency hull FEA within 72 hours for Korean-government salvage support; automated ANSYS workflows with Python.
+
+### Engineering SME for Data Science Team, Occidental Petroleum
+**Sep 2017 - Dec 2020 | Houston, TX & Remote**
+
+- Domain engineering lead bridging production engineering, drilling, data science, and software teams for large-scale analytics deployment.
+- **Production optimization platform:** Deployed 50+ physics-based algorithms monitoring ~20,000 wells in real time with logging, exception handling, and production-support workflows.
+- **Real-time drilling analytics:** Bit-position estimation, torque/drag monitoring, rig-state logic, and edge-computing workflows across 20+ concurrent drilling campaigns.
+- **Production surveillance:** Automated dynacard analysis, ESP surveillance, well-test validation, and time-shed analytics. Designed SQL data models, Python class libraries, analytics pipelines, and dashboards - the production-analytics foundation Deckhand builds on.
+
+### Engineering Lead, 2H Offshore Inc
+**Aug 2003 - Jun 2015 | Houston, TX**
+
+- Progressed through analyst, lead, manager, and technical-authority roles for riser design, subsea systems, installation analysis, integrity management, and API standards work.
+- **BP Macondo emergency response:** Engineering Manager for the containment riser response; led a 24/7 multidisciplinary effort across multiple locations and delivered a complete design in 8 weeks by repurposing existing assets.
+- **Chevron Bangka SCR/flexible riser FEED:** Led FEED for production risers in shallow-water development, optimizing configuration and installation strategy ahead of schedule.
+- **Major riser and integrity portfolio:** Led or supported BP Thunder Horse, Atlantis, Horn Mountain; Chevron Jack/St. Malo; ENI Devils Tower; Reliance KG-D6; Shell/BP HPHT systems; and developments across the Gulf of Mexico, West Africa, and Asia-Pacific.
+- **API standards contribution:** Committee member/contributor for API-RP-16Q and related riser/structural standards. Delivered 100+ assignments.
+
+---
+
+## Selected Live API Paths & Proof
+
+- **Mooring fatigue / global analysis** - DNV-traceable screening, returns a published report URL (offshore, live).
+- **Subsea-pipeline screening** - DNV-RP-F105-traceable, deterministic across hundreds of golden cases (offshore, live).
+- **Installation / umbilical-window analysis** - reframed from ExxonMobil Yellowtail and Talos engagements (offshore, live).
+- **Field-economics screening** - BSEE-data analytics over 200+ GoM fields (offshore, live).
+- **Onboarding (roadmap, not yet shipped):** CAD/CAM, manufacturing, electrical, and safety API paths.
+
+## Education & Credentials
+
+**Master of Science, Mechanical Engineering** - Texas A&M University, College Station, TX<br>
+**Bachelor of Technology, Mechanical Engineering** - Indian Institute of Technology (IIT), Madras, India
+
+**Professional Engineer (P.E.)** - Texas<br>
+**API Standards Committee Experience:** API-RP-16Q, API-RP-17G, API-RP-17G2
+
+## Selected Publications & Thought Leadership
+
+- **World Oil (2024):** "Wellbay Innovation Supports Lower-Cost HP DW Discoveries"
+- **OTC (2017):** "Heavy Lift Dynamics - Sewol Ferry Offshore Salvage"
+- **IADC (2015):** Contributing Author, *Floating Drilling Equipment and Operations*, 12th Edition
+- **OMAE (2009):** "Benchmarking SHEAR7v4.5: Full-Scale Drilling Riser VIV Data"
+- **World Oil Industry Reference (April 2026):** "SF Offshore Technology - Shilling (Frontier Deepwater Appraisal Solutions LLC)"
+
+## Professional Affiliations
+
+Society of Petroleum Engineers (SPE) | American Society of Mechanical Engineers (ASME) | Marine Technology Society (MTS) | API Standards Committees
+
+## Languages
+
+English - Excellent | Telugu - Excellent | Hindi - Good
+
+## References
+
+Available upon request.


### PR DESCRIPTION
## What

Reframes Vamsee Achanta's career surfaces from **"naval-architect job-seeker"** to **firm-first: founder building Deckhand — the API for real-world engineering work.**

Core narrative across all three drafts: every engineering workflow is an API path; one call (`POST /api/run`) returns a **standards-traceable HTML report URL**, built on open-source `digitalmodel` (7,000+ standard-mapped functions, 42 standards). The 23+ year naval-architecture / subsea / mooring / installation record becomes the **credibility beneath the platform**, not the headline.

### New headline (resume + LinkedIn)
> **Founder, AceEngineer / Deckhand — the API for real-world engineering work**

LinkedIn headline (199 chars):
> Founder, AceEngineer / Deckhand - the API for real-world engineering work | One call returns a standards-traceable report URL | P.E., 23+ yrs offshore & subsea as the credibility beneath the platform

## Files (all new drafts — canonical `cv/va_resume.md` untouched)
- `cv/va_resume_apibuilder.md` — firm-first resume; platform/founder story leads, engineering record supports it as proof. Same pandoc/frontmatter conventions so the GitHub Actions build still works.
- `cv/linkedin/profile-api-centric.md` — structured LinkedIn draft: Headline (≤220), About (ends with soft CTA to a live report URL), Featured, Experience, Skills.
- `cv/career-page-api-centric.md` — portfolio copy tied to live API paths + report URLs.

## Honesty / banned-claims compliance
Offshore is the live proof. CAD/CAM, manufacturing, electrical, and safety are framed only as **onboarding** API paths (roadmap) — never claimed as shipped capability. No key-man / "AI-native engineer" framing.

## HITL
Drafts only; nothing posted to LinkedIn; canonical `va_resume.md` untouched. Bracketed `[...]` URLs are placeholders for Vamsee to fill with real live links before publishing.

Ref: aceengineer-strategy#94 · teamresumes #14 #15 #16 #17 #18 #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)