### PR TITLE
LinkedIn: CV-aligned profile source of truth (repo-maintained, live-link driven)

### DIFF
--- a/cv/linkedin/profile-cv-aligned.md
+++ b/cv/linkedin/profile-cv-aligned.md
@@ -1,0 +1,189 @@
+# LinkedIn Profile — CV-aligned source of truth
+
+> **DRAFT — Vamsee posts manually; nothing here is auto-published.**
+> This file is the maintainable source for the live LinkedIn profile, kept consistent
+> with `cv/va_resume.md` (the job-search CV). Update flow: edit here → PR → paste the
+> changed section into LinkedIn. Voice: **engineer-first** (matches the CV), with
+> Deckhand/platform work as a highlight — not the headline identity. For the
+> founder-first alternative voice see `profile-api-centric.md`.
+>
+> Honesty rule: offshore work is live proof; anything not shipped (CAD/CAM,
+> manufacturing, electrical, safety domains) is never claimed as delivered capability.
+> Numbers must match the CV (which is verified against the repos) — no unverified claims.
+
+---
+
+## Link registry (stable live URLs — use these everywhere)
+
+| Purpose | URL |
+|---|---|
+| Career site (portfolio landing) | https://vamseeachanta.github.io/teamresumes/ |
+| Resume (PDF download) | https://vamseeachanta.github.io/teamresumes/va_resume.pdf |
+| Deckhand demo gallery | https://vamseeachanta.github.io/deckhand-sandbox/ |
+| digitalmodel capabilities | https://vamseeachanta.github.io/digitalmodel/capabilities/ |
+| worldenergydata (GoM analytics) | https://vamseeachanta.github.io/worldenergydata/ |
+| worldenergydata capabilities | https://vamseeachanta.github.io/worldenergydata/capabilities/ |
+| GitHub | https://github.com/vamseeachanta |
+
+These are Pages roots / stable aliases — they do not change as content underneath is
+improved, so LinkedIn never needs re-editing when the work evolves.
+
+---
+
+## Headline (≤220 chars)
+
+> Naval Architect | Subsea & Marine Systems Engineering Leader | P.E. (Texas) | 23+ yrs risers, moorings, LNG marine, installation | Building Deckhand — deterministic engineering-workflows API | OrcaFlex · AQWA · Python
+
+---
+
+## About (≤2,600 chars)
+
+Marine/offshore engineering leader with 23+ years across naval architecture, subsea
+systems, risers, pipelines, umbilicals, moorings, installation engineering, integrity
+management, and engineering automation. Professional Engineer (Texas) with a track
+record leading high-consequence offshore work from concept/FEED through detailed
+analysis, installation support, operations, and emergency response — including
+Engineering Manager for the BP Macondo containment riser response (complete design in
+8 weeks by repurposing existing assets).
+
+Current and concurrent roles:
+• Naval Architect, Alan C. McClure Associates — coupled marine global analysis,
+diffraction, moorings; WoodFibre LNG FST terminal design ($1.8B, British Columbia)
+• VP of Engineering / Co-Founder, Frontier Deepwater (FDAS) — deepwater production
+concepts, riser/mooring systems, GoM field economics
+• Engineering Lead Consultant, AceEngineer — subsea/riser/installation analysis, FEA,
+fitness-for-service, digital twins, open engineering & AI tooling
+
+I combine hands-on technical authority in OrcaFlex, AQWA, OrcaWave, ANSYS, Abaqus, and
+COMSOL with Python/SQL automation: converting engineering workflows into repeatable
+digital tools, digital twins, and production-grade analytics that cut analysis cycle
+time without sacrificing standards traceability.
+
+Everything I claim is demonstrable, live, and open:
+• Deckhand — API-first platform with ~30 deterministic, standards-based screening
+workflows (fatigue, seakeeping, lifting, weather windows), provenance-gated licensed
+OrcaFlex/AQWA runs: https://vamseeachanta.github.io/deckhand-sandbox/
+• digitalmodel — open offshore engineering library (221 S-N fatigue curves across 17
+standards, diffraction benchmarks, validated OpenFOAM CFD suite, floating-wind sizing):
+https://vamseeachanta.github.io/digitalmodel/capabilities/
+• worldenergydata — live GoM field economics & well analytics on public BSEE data:
+https://vamseeachanta.github.io/worldenergydata/
+
+Full resume: https://vamseeachanta.github.io/teamresumes/
+
+---
+
+## Featured (3 items, in order)
+
+1. **Career site + resume** — https://vamseeachanta.github.io/teamresumes/
+2. **Deckhand demo gallery (live)** — https://vamseeachanta.github.io/deckhand-sandbox/
+3. **digitalmodel capabilities (live)** — https://vamseeachanta.github.io/digitalmodel/capabilities/
+
+---
+
+## Experience
+
+### Naval Architect — Alan C. McClure Associates, Inc.
+*Dec 2023 – Present · Houston, TX*
+
+- WoodFibre LNG Terminal design ($1.8B, British Columbia): marine global analysis for
+  dual Floating Storage Terminals — coupled FST/shore-mooring analysis for extreme
+  weather, FST/LNGC/fender/mooring interaction, mooring for LNG carriers to 180,000 m³,
+  via AQWA/OrcaWave/OrcaFlex.
+- Diffraction and mooring-failure investigations for moored barges in extreme weather;
+  tug floundering / passing-ship time-domain analysis.
+- Python/API digital twins for hull diffraction (AQWA/OrcaWave) and mooring workflows
+  (OrcFxAPI): automated model creation, execution, extraction, and reporting.
+
+### VP of Engineering / Co-Founder — Frontier Deepwater Appraisal Solutions (FDAS)
+*Jun 2016 – Present · Houston, TX*
+
+- Deepwater field-development concepts: 6,000 ft water-depth semisubmersible production
+  vessel concept from idle 6th-generation drillships — riser, mooring, and
+  hurricane-condition analysis.
+- SQL/Python field-economics platform on BSEE data for 200+ GoM fields — field
+  evaluation reduced from weeks to days.
+- SEWOL salvage: emergency hull FEA delivered in 72 hours for Korean government
+  salvage support, with Python-automated ANSYS workflows.
+
+### Engineering Lead Consultant — AceEngineer
+*Jun 2012 – Present · Houston, TX & Remote*
+
+- Specialist offshore/subsea consulting: installation analysis (ExxonMobil Yellowtail
+  ~6,000 ft umbilicals, Chevron Ballymore jumpers/manifolds, Talos Venice Limerock,
+  42-inch D/t=67 Venezuela pipeline), risers, structural FEA, corrosion,
+  API 579 / BS 7910 fitness-for-service.
+- Deckhand — engineering-workflows API: request in → deterministic analysis →
+  report URL out; ~30 standards-based screening workflows, versioned algorithms,
+  provenance-gated licensed OrcaFlex/AQWA runs. Live:
+  https://vamseeachanta.github.io/deckhand-sandbox/
+- Open engineering: digitalmodel (221 S-N curves/17 standards, validated OpenFOAM CFD
+  suite, vessel/rig database of 2,268 rigs + 165 construction vessels, floating-wind
+  sizing) and worldenergydata (live GoM field economics) — every result unit-tested and
+  provenance-traced. AI/LLM as narrative support over deterministic cores.
+- Marine safety / HSE analytics: BSEE incident-database analytics (1,987 GoM incidents)
+  powering incident-grounded failure-mode and seasonal-preparedness reports.
+
+### Engineering SME, Data Science Team — Occidental Petroleum
+*Sep 2017 – Dec 2020 · Houston, TX & Remote*
+
+- Domain engineering lead bridging production, drilling, data-science, and software
+  teams: 50+ physics-based algorithms monitoring ~20,000 wells in real time.
+- Real-time drilling analytics (bit position, torque/drag, rig-state) for 20+
+  concurrent campaigns; dynacard/ESP surveillance and well-test validation.
+
+### Engineering Lead — 2H Offshore Inc
+*Aug 2003 – Jun 2015 · Houston, TX*
+
+- Engineering Manager, BP Macondo containment riser response — 24/7 multidisciplinary
+  effort, complete design in 8 weeks by repurposing existing assets.
+- 100+ riser/subsea assignments: BP Thunder Horse, Atlantis, Horn Mountain; Chevron
+  Jack/St. Malo, Bangka FEED; ENI Devils Tower; Reliance KG-D6; Shell/BP HPHT.
+- API-RP-16Q committee contributor.
+
+---
+
+## Education
+
+- **Texas A&M University** — MS, Mechanical Engineering
+- **Indian Institute of Technology (IIT), Madras** — B.Tech, Mechanical Engineering
+
+## Licenses & Certifications
+
+- **Professional Engineer (P.E.)** — Texas
+- API Standards Committees: API-RP-16Q, API-RP-17G, API-RP-17G2
+
+## Publications (match CV list)
+
+- World Oil (2024) — "Wellbay Innovation Supports Lower-Cost HP DW Discoveries"
+- OTC (2017) — "Heavy Lift Dynamics — Sewol Ferry Offshore Salvage"
+- IADC (2015) — Contributing Author, *Floating Drilling Equipment and Operations*, 12th Ed.
+- OMAE (2009) — "Benchmarking SHEAR7v4.5: Full-Scale Drilling Riser VIV Data"
+- World Oil Industry Reference (April 2026) — "SF Offshore Technology—Shilling (FDAS LLC)"
+
+## Skills (ordered, top 20)
+
+1. Naval Architecture
+2. Subsea Engineering
+3. Riser Design & Analysis
+4. Mooring Analysis
+5. Installation Engineering
+6. OrcaFlex / OrcFxAPI
+7. ANSYS AQWA / OrcaWave (diffraction)
+8. Finite Element Analysis (ANSYS, Abaqus)
+9. CFD (OpenFOAM)
+10. Fitness-for-Service (API 579, BS 7910)
+11. DNV / API Offshore Standards
+12. LNG Marine Operations
+13. Floating Offshore Wind
+14. Python Automation
+15. SQL & Engineering Analytics
+16. Digital Twins
+17. Engineering Workflow APIs (Deckhand)
+18. AI-Augmented Engineering
+19. Emergency Response Engineering
+20. Engineering Team Leadership
+
+## Organizations
+
+SPE · ASME · Marine Technology Society · API Standards Committees


### PR DESCRIPTION
Adds `cv/linkedin/profile-cv-aligned.md` — the maintainable source for the live LinkedIn profile, per the direction that the profile should be maintainable via the teamresumes repo and lean on the always-improving live GitHub links.

- **Engineer-first voice matching `cv/va_resume.md`** (the founder-first `profile-api-centric.md` remains as the alternative).
- **Link registry** of stable Pages URLs (career site, resume PDF, Deckhand gallery, digitalmodel/worldenergydata capabilities) — roots/aliases that don't change as content evolves, so LinkedIn rarely needs re-editing.
- Section-by-section paste-ready copy: headline (217/220 chars), About (2,045/2,600), Featured, 5 experience entries mirroring the CV, education/credentials, publications, 20 ordered skills.
- All numbers match the CV (verified against repos); nothing unshipped is claimed.
- Manual-post only — nothing auto-publishes.

Refs #17 (epic #14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)