### PR TITLE
docs(linkedin): record published Featured-link deviation after applying SSOT (#17)

### DIFF
--- a/cv/linkedin/profile-cv-aligned.md
+++ b/cv/linkedin/profile-cv-aligned.md
@@ -79,6 +79,14 @@ Full resume: https://vamseeachanta.github.io/teamresumes/
 2. **Deckhand demo gallery (live)** — https://vamseeachanta.github.io/deckhand-sandbox/
 3. **digitalmodel capabilities (live)** — https://vamseeachanta.github.io/digitalmodel/capabilities/
 
+> **Published deviation (2026-07-02):** LinkedIn's link resolver follows the
+> meta-refresh redirect on the deckhand-sandbox root, so the live Featured item 2
+> is stored as `https://vamseeachanta.github.io/deckhand-sandbox/review-94111d02a8/`
+> (URL not editable after creation; only title/description are). The intended
+> stable alias remains the root URL above. Fix that makes the alias stick: serve
+> real content (or a server-side redirect) at the sandbox root instead of a
+> meta-refresh page, then re-add the Featured link.
+
 ---
 
 ## Experience


### PR DESCRIPTION
## Summary
The LinkedIn profile was updated live from the SSOT (`cv/linkedin/profile-cv-aligned.md`) on 2026-07-02 per the handover doc. Every section applied verbatim except one URL: LinkedIn's link resolver followed the meta-refresh redirect on the deckhand-sandbox root, so Featured item 2 is published as `.../deckhand-sandbox/review-94111d02a8/` (the URL field is not editable after creation).

This PR annotates the SSOT's Featured section with the published deviation and the repo-side fix (serve real content at the sandbox root instead of a meta-refresh, then re-add the link), so the SSOT stays true to what is live.

Full per-section report: see comment on #17.

Refs #17